### PR TITLE
fix: security patches for react-router vulnerabilities

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -5519,9 +5519,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
-      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -5541,12 +5541,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
-      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.17.0"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"


### PR DESCRIPTION
## Security Fix PR

### Vulnerabilities Fixed
This PR addresses 2 moderate severity vulnerabilities in react-router:

1. **CVE-2025-68470 bypass** - Open redirect via backslash in \<Link> and useNavigate
2. **GHSA-h8fp-f39c-q6mh** - RSCErrorHandler Missing Protocol Validation (XSS)
3. **GHSA-337j-9hxr-rhxg** - Arbitrary Constructor Injection via deserializeErrors() in React Router SSR Hydration

### Changes
- Updated react-router and react-router-dom to latest patched versions via `npm audit fix`

### Verification
- Build passes (`npm run build`)
- Unit tests pass (306 tests)
- Lint passes (only pre-existing warnings)

### Note
This PR was created by an autonomous GitHub Security Maintenance Agent (OpenHands).