### PR TITLE
Complete tenant-scoped consent management

### DIFF
--- a/app/server/schemas/consent.schema.js
+++ b/app/server/schemas/consent.schema.js
@@ -69,9 +69,17 @@ export const BuilderConfigSchema = z.object({
   reopenSelector: z.string().max(200).default(''),
 });
 
+export const ConsentControllerSchema = z.object({
+  name: z.string().max(200),
+  email: z.string().email().max(254),
+  country: z.string().max(100).default(''),
+  address: z.string().max(500).default(''),
+});
+
 export const ConsentConfigBodySchema = z.object({
   mode: z.enum(['disabled', 'hardcoded', 'builder']),
   enabled: z.boolean(),
+  controller: ConsentControllerSchema.optional(),
   legalPolicies: LegalPoliciesSchema.optional().default({}),
   hardcoded: HardcodedConfigSchema.optional().default({}),
   builder: BuilderConfigSchema.optional().default({}),

--- a/app/src/components/AdminView.tsx
+++ b/app/src/components/AdminView.tsx
@@ -1054,6 +1054,8 @@ export const AdminView = ({
           <TabsContent value="privacy" className="admin-tab-content">
             <div data-onboarding="privacy-section">
               <PrivacySettings
+                pageName={profile.name}
+                cmpSiteUrl={publicPageHref}
                 privacyPolicyUrl={profile.privacyPolicyUrl}
                 cookiePolicyUrl={profile.cookiePolicyUrl}
                 readOnly={DEMO_MODE}

--- a/app/src/components/CookieBanner.tsx
+++ b/app/src/components/CookieBanner.tsx
@@ -444,7 +444,7 @@ function BannerBody({ cfg, colors, onAcceptAll, onRejectAll, onOpenPrefs, hasOpt
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center', flexShrink: 0 }}>
         {rejectFirst ? (
           <>
-            <Btn colors={colors} onClick={onRejectAll}>{cfg.texts.rejectAll}</Btn>
+            <Btn colors={colors} onClick={onRejectAll} primary>{cfg.texts.rejectAll}</Btn>
             {hasOptionalCats && (
               <Btn colors={colors} onClick={onOpenPrefs}>{cfg.texts.managePreferences}</Btn>
             )}
@@ -455,7 +455,7 @@ function BannerBody({ cfg, colors, onAcceptAll, onRejectAll, onOpenPrefs, hasOpt
             {hasOptionalCats && (
               <Btn colors={colors} onClick={onOpenPrefs}>{cfg.texts.managePreferences}</Btn>
             )}
-            <Btn colors={colors} onClick={onRejectAll}>{cfg.texts.rejectAll}</Btn>
+            <Btn colors={colors} onClick={onRejectAll} primary>{cfg.texts.rejectAll}</Btn>
             <Btn colors={colors} onClick={onAcceptAll} primary>{cfg.texts.acceptAll}</Btn>
           </>
         )}

--- a/app/src/components/PrivacySettings.tsx
+++ b/app/src/components/PrivacySettings.tsx
@@ -150,6 +150,116 @@ const EMPTY_POLICY_CONFIG = {
   embeddedCode: '',
 };
 
+function generatedPolicies(input: {
+  language: 'it' | 'en';
+  controller: { name: string; email: string; country?: string; address?: string };
+  policyVersion: string;
+  categories: NonNullable<ConsentConfigData['hardcoded']>['categories'];
+}) {
+  const { controller, language, policyVersion, categories } = input;
+  const identity = [controller.name, controller.address, controller.country].filter(Boolean).join(', ');
+  const enabled = Object.entries(categories)
+    .filter(([, category]) => category.enabled)
+    .map(([, category]) => `- ${category.title}: ${category.description}`)
+    .join('\n');
+  if (language === 'it') {
+    return {
+      privacy: `PRIVACY POLICY
+Versione ${policyVersion}
+
+1. Titolare del trattamento
+${identity}
+Contatto privacy: ${controller.email}
+
+2. Dati trattati
+Questa pagina può trattare dati tecnici strettamente necessari alla sicurezza e al funzionamento del servizio. Se il titolare attiva moduli, newsletter, Shop o prenotazioni, vengono inoltre trattati i dati inviati volontariamente dall’utente e quelli necessari a gestire la richiesta, il pagamento, la consegna o l’appuntamento.
+
+3. Finalità e basi giuridiche
+I dati necessari vengono trattati per erogare il servizio richiesto, adempiere obblighi di legge e proteggere la pagina. Analytics, personalizzazione e contenuti di terze parti vengono attivati solo in base alle scelte espresse nel banner, quando richiesto.
+
+4. Fornitori e trasferimenti
+OrbitPage fornisce l’infrastruttura della pagina. Eventuali servizi esterni scelti dal titolare (ad esempio analytics, video, mappe, calendario o moduli) ricevono dati soltanto dopo il consenso previsto e applicano le proprie informative. Alcuni fornitori possono trattare dati fuori dallo SEE usando le garanzie previste dalla normativa applicabile.
+
+5. Conservazione
+I dati sono conservati per il tempo necessario alle finalità indicate e agli obblighi legali. Le scelte cookie sono conservate per il periodo indicato nella Cookie Policy; la prova tecnica del consenso è conservata per un massimo di 24 mesi.
+
+6. Diritti
+L’interessato può chiedere accesso, rettifica, cancellazione, limitazione, portabilità e opposizione, nonché revocare il consenso in qualsiasi momento dal comando “Preferenze cookie”. Le richieste possono essere inviate a ${controller.email}. Resta possibile proporre reclamo all’autorità di controllo competente.
+
+7. Aggiornamenti
+Il titolare può aggiornare questa informativa. La versione pubblicata su questa pagina è quella vigente.`,
+      cookie: `COOKIE POLICY
+Versione ${policyVersion}
+
+1. Titolare
+${identity}
+Contatto privacy: ${controller.email}
+
+2. Cosa utilizza la pagina
+OrbitPage usa storage strettamente necessario per ricordare le scelte privacy, proteggere il servizio e mantenere le funzioni richieste dall’utente. Gli strumenti opzionali restano bloccati fino alla scelta del visitatore.
+
+3. Categorie opzionali configurate
+${enabled || '- Nessuna categoria opzionale attiva.'}
+
+4. Servizi di terze parti
+Video, mappe, calendari, moduli, social embed e strumenti analytics possono comunicare con i rispettivi fornitori soltanto dopo il consenso della categoria associata. Prima del consenso viene mostrato un segnaposto e non viene inviata alcuna richiesta al provider.
+
+5. Durata e prova del consenso
+Le preferenze vengono conservate in modo separato per questa specifica pagina per il periodo configurato dal titolare. OrbitPage registra una ricevuta tecnica delle scelte, senza IP o email del visitatore, per un massimo di 24 mesi.
+
+6. Gestione e revoca
+Il visitatore può accettare, rifiutare o scegliere singole categorie. La scelta può essere modificata o revocata in qualsiasi momento tramite “Preferenze cookie”, sempre disponibile sulla pagina.`,
+    };
+  }
+  return {
+    privacy: `PRIVACY POLICY
+Version ${policyVersion}
+
+1. Data controller
+${identity}
+Privacy contact: ${controller.email}
+
+2. Data processed
+This page may process technical data strictly necessary for security and operation. If the controller enables forms, newsletters, Shop or booking, it also processes data voluntarily submitted by the visitor and data needed to handle the request, payment, delivery or appointment.
+
+3. Purposes and legal bases
+Necessary data is processed to provide requested services, comply with law and protect the page. Analytics, personalisation and third-party content are enabled according to the choices made in the consent banner where consent is required.
+
+4. Providers and transfers
+OrbitPage provides the page infrastructure. External services selected by the controller receive data only after the required consent and apply their own notices. Some providers may process data outside the EEA using safeguards required by applicable law.
+
+5. Retention
+Data is retained only as long as needed for the stated purposes and legal obligations. Cookie choices follow the Cookie Policy; technical consent evidence is kept for up to 24 months.
+
+6. Rights
+Visitors may request access, correction, deletion, restriction, portability or objection and may withdraw consent at any time through “Cookie preferences”. Requests can be sent to ${controller.email}; complaints may be filed with the competent supervisory authority.
+
+7. Updates
+The controller may update this notice. The version published on this page is the current version.`,
+    cookie: `COOKIE POLICY
+Version ${policyVersion}
+
+1. Controller
+${identity}
+Privacy contact: ${controller.email}
+
+2. What this page uses
+OrbitPage uses strictly necessary storage to remember privacy choices, protect the service and maintain functions requested by the visitor. Optional tools remain blocked until the visitor makes a choice.
+
+3. Configured optional categories
+${enabled || '- No optional category is active.'}
+
+4. Third-party services
+Video, maps, calendars, forms, social embeds and analytics may contact their providers only after consent for the associated category. Before consent, a placeholder is shown and no provider request is made.
+
+5. Duration and consent evidence
+Preferences are stored separately for this specific page for the period configured by the controller. OrbitPage records technical evidence of the choices, without the visitor’s IP or email, for up to 24 months.
+
+6. Management and withdrawal
+Visitors can accept, reject or select individual categories. Choices can be changed or withdrawn at any time through “Cookie preferences”, which remains available on the page.`,
+  };
+}
+
 // ── Sub-components ────────────────────────────────────────────────────────────
 
 function SectionHeader({ icon: Icon, title, description }: {
@@ -875,11 +985,15 @@ function ModeCard({
 // ── Root Component ────────────────────────────────────────────────────────────
 
 export function PrivacySettings({
+  pageName,
+  cmpSiteUrl,
   privacyPolicyUrl,
   cookiePolicyUrl,
   onLegalPolicyUpdate,
   readOnly = false,
 }: {
+  pageName?: string;
+  cmpSiteUrl?: string;
   privacyPolicyUrl?: string;
   cookiePolicyUrl?: string;
   onLegalPolicyUpdate?: (links: { privacyPolicyUrl?: string; cookiePolicyUrl?: string }) => void | Promise<void>;
@@ -904,6 +1018,7 @@ export function PrivacySettings({
   const [cookieHostedFileName, setCookieHostedFileName] = useState('');
   const [privacyProviderConfig, setPrivacyProviderConfig] = useState('');
   const [cookieProviderConfig, setCookieProviderConfig] = useState('');
+  const [controller, setController] = useState({ name: pageName || '', email: '', country: '', address: '' });
 
   const [mode, setMode] = useState<ConsentMode>('disabled');
   const [enabled, setEnabled] = useState(false);
@@ -918,9 +1033,10 @@ export function PrivacySettings({
       try {
         const res = await consentConfigApi.get();
         if (res?.data) {
-          const { mode: m, enabled: e, legalPolicies: lp, hardcoded: h, builder: b } = res.data;
+          const { mode: m, enabled: e, controller: savedController, legalPolicies: lp, hardcoded: h, builder: b } = res.data;
           setMode(m === 'builder' ? 'builder' : 'hardcoded');
           setEnabled(e ?? false);
+          if (savedController) setController({ name: savedController.name, email: savedController.email, country: savedController.country || '', address: savedController.address || '' });
           if (lp) {
             const privacyPolicy = { ...EMPTY_POLICY_CONFIG, ...lp.privacyPolicy };
             const cookiePolicy = { ...EMPTY_POLICY_CONFIG, ...lp.cookiePolicy };
@@ -1010,6 +1126,7 @@ export function PrivacySettings({
   const privacySnapshot = useMemo(() => JSON.stringify({
     mode,
     enabled,
+    controller,
     hardcoded,
     builder: normalizedBuilder,
     legalPolicies: {
@@ -1035,6 +1152,7 @@ export function PrivacySettings({
     cookieMethod,
     cookieProviderConfig,
     enabled,
+    controller,
     hardcoded,
     mode,
     normalizedBuilder,
@@ -1063,6 +1181,10 @@ export function PrivacySettings({
     try {
       const nextPrivacyPolicyUrl = resolvedPrivacyPolicyUrl;
       const nextCookiePolicyUrl = resolvedCookiePolicyUrl;
+      if ((controller.name.trim() || controller.email.trim()) && (!controller.name.trim() || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(controller.email.trim()))) {
+        setSaveError('Add a valid controller name and privacy email, or leave both fields empty.');
+        return;
+      }
 
       if (mode === 'hardcoded' && enabled && !nextPrivacyPolicyUrl && !nextCookiePolicyUrl) {
         setSaveError('Add at least one legal policy link before enabling the native banner.');
@@ -1123,7 +1245,10 @@ export function PrivacySettings({
         },
       };
 
-      const res = await consentConfigApi.update({ mode, enabled, legalPolicies, hardcoded, builder: nextBuilder });
+      const normalizedController = controller.name.trim() && controller.email.trim()
+        ? { name: controller.name.trim(), email: controller.email.trim(), country: controller.country.trim(), address: controller.address.trim() }
+        : undefined;
+      const res = await consentConfigApi.update({ mode, enabled, controller: normalizedController, legalPolicies, hardcoded, builder: nextBuilder });
       if (!res.success) {
         setSaveError((res as { error?: string }).error || 'Save failed.');
       } else {
@@ -1316,6 +1441,56 @@ export function PrivacySettings({
               </div>
               <Globe2 />
             </div>
+            <div className="mb-6 border-y border-slate-200 bg-slate-50/70 px-4 py-5">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <FieldRow label={tr('Data controller name', 'Nome del titolare')}>
+                  <Input className="admin-input" value={controller.name} onChange={(event) => setController((current) => ({ ...current, name: event.target.value }))} maxLength={200} placeholder={pageName || 'Business or professional name'} />
+                </FieldRow>
+                <FieldRow label={tr('Privacy email', 'Email privacy')}>
+                  <Input className="admin-input" type="email" value={controller.email} onChange={(event) => setController((current) => ({ ...current, email: event.target.value }))} maxLength={254} placeholder="privacy@example.com" />
+                </FieldRow>
+                <FieldRow label={tr('Country', 'Paese')}>
+                  <Input className="admin-input" value={controller.country} onChange={(event) => setController((current) => ({ ...current, country: event.target.value }))} maxLength={100} placeholder="Italy" />
+                </FieldRow>
+                <FieldRow label={tr('Address (optional)', 'Indirizzo (opzionale)')}>
+                  <Input className="admin-input" value={controller.address} onChange={(event) => setController((current) => ({ ...current, address: event.target.value }))} maxLength={500} />
+                </FieldRow>
+              </div>
+              <div className="mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-slate-200 pt-4">
+                <p className="max-w-xl text-xs leading-5 text-slate-600">
+                  {tr('Generate editable starter documents from these details and the active consent categories. Review them for your specific activity before publishing.', 'Genera documenti iniziali modificabili da questi dati e dalle categorie attive. Verificali rispetto alla tua attività prima di pubblicare.')}
+                </p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    if (!controller.name.trim() || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(controller.email.trim())) {
+                      setSaveError(tr('Add the controller name and a valid privacy email first.', 'Inserisci prima il nome del titolare e un’email privacy valida.'));
+                      return;
+                    }
+                    const policyVersion = new Date().toISOString().slice(0, 10);
+                    const docs = generatedPolicies({
+                      language: document.documentElement.lang.toLowerCase().startsWith('it') ? 'it' : 'en',
+                      controller: { ...controller, name: controller.name.trim(), email: controller.email.trim() },
+                      policyVersion,
+                      categories: hardcoded.categories,
+                    });
+                    setHardcoded((current) => ({ ...current, policyVersion }));
+                    setShowLegalLinks(true);
+                    setPrivacyMethod('hosted');
+                    setCookieMethod('hosted');
+                    setPrivacyHostedText(docs.privacy);
+                    setCookieHostedText(docs.cookie);
+                    setPrivacyHostedFileName('privacy-policy.txt');
+                    setCookieHostedFileName('cookie-policy.txt');
+                    setSaveError('');
+                  }}
+                >
+                  <FileText className="h-4 w-4" />
+                  {tr('Generate starter policies', 'Genera policy iniziali')}
+                </Button>
+              </div>
+            </div>
             <LegalPoliciesForm
               showLegalLinks={showLegalLinks}
               onShowLegalLinksChange={setShowLegalLinks}
@@ -1426,6 +1601,26 @@ export function PrivacySettings({
                   title={tr('External CMP', 'CMP esterna')}
                   description={tr('Configure the provider that will display the consent interface.', 'Configura il provider che mostrerà l’interfaccia di consenso.')}
                 />
+                {cmpSiteUrl ? (
+                  <div className="mb-5 border-y border-blue-200 bg-blue-50/70 px-4 py-4">
+                    <Label className="text-xs font-semibold uppercase tracking-[0.14em] text-blue-800">
+                      {tr('Site URL to register with the CMP', 'URL del sito da registrare nella CMP')}
+                    </Label>
+                    <div className="mt-2 flex flex-col gap-2 sm:flex-row">
+                      <Input className="admin-input font-mono text-xs" readOnly value={cmpSiteUrl} />
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => void navigator.clipboard?.writeText(cmpSiteUrl)}
+                      >
+                        {tr('Copy URL', 'Copia URL')}
+                      </Button>
+                    </div>
+                    <p className="mt-2 text-xs leading-5 text-blue-900/70">
+                      {tr('Use this exact public page URL, including the slug. Do not enter the OrbitPage dashboard URL.', 'Usa esattamente questo URL pubblico, slug incluso. Non inserire l’URL della dashboard OrbitPage.')}
+                    </p>
+                  </div>
+                ) : null}
                 <BuilderForm
                   cfg={builder}
                   onChange={(updates) => setBuilder((previous) => ({ ...previous, ...updates }))}

--- a/app/src/components/PublicMapCard.tsx
+++ b/app/src/components/PublicMapCard.tsx
@@ -1,8 +1,10 @@
 import { Card } from "@/components/ui/card";
+import { useEffect, useState } from "react";
 import type { LinkData } from "./LinkCard";
 import { getMapData } from "@/lib/link-blocks";
 import { trackPublicLinkClick } from "@/lib/public-runtime";
-import { ArrowUpRight, MapPinned, Navigation } from "lucide-react";
+import { ArrowUpRight, MapPinned, Navigation, ShieldCheck } from "lucide-react";
+import { consentManager } from "@/lib/consent-manager";
 import { getPublicBlockPadding, getPublicBlockStyle, getPublicButtonStyle, getPublicIconContent } from "@/lib/public-block-style";
 import {
   extractMapCoordinates,
@@ -62,6 +64,12 @@ const RealMapPreview = ({ coordinates, label }: { coordinates: MapCoordinates; l
 );
 
 export const PublicMapCard = ({ link }: PublicMapCardProps) => {
+  const [mapConsent, setMapConsent] = useState(() => consentManager.isGranted("preferences"));
+  useEffect(() => {
+    const syncConsent = () => setMapConsent(consentManager.isGranted("preferences"));
+    syncConsent();
+    return consentManager.onConsentChange(syncConsent);
+  }, []);
   const { placeName, address, mapUrl, latitude, longitude } = getMapData(link.content);
   const mapQuery = getMapQuery(placeName, address, link.title, mapUrl);
   const coordinates = toMapCoordinates(latitude, longitude)
@@ -86,11 +94,25 @@ export const PublicMapCard = ({ link }: PublicMapCardProps) => {
   return (
     <Card className="glass-card overflow-hidden p-0" style={cardStyle}>
       <div className={`relative overflow-hidden bg-muted/30 ${link.size === "small" ? "h-32" : link.size === "large" ? "h-52" : "h-40"}`}>
-        {coordinates ? (
+        {coordinates && mapConsent ? (
           <RealMapPreview coordinates={coordinates} label={mapQuery || placeName || address || link.title || "Map"} />
         ) : (
           <MapLocationFallback label={mapQuery || placeName || address || link.title || "Map"} />
         )}
+        {coordinates && !mapConsent ? (
+          <button
+            type="button"
+            onClick={() => {
+              consentManager.showBanner();
+              consentManager.openPreferences();
+            }}
+            className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-slate-950/70 px-5 text-center text-white"
+          >
+            <ShieldCheck className="h-6 w-6" />
+            <strong className="mt-2 text-sm">Map blocked until consent</strong>
+            <span className="mt-1 text-xs text-white/75">Open cookie preferences to load OpenStreetMap.</span>
+          </button>
+        ) : null}
         <div className="pointer-events-none absolute left-3 top-3 flex h-10 w-10 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg ring-2 ring-background/70" style={getPublicButtonStyle(link)}>
           {getPublicIconContent(link, <MapPinned className="h-4 w-4" />)}
         </div>

--- a/app/src/components/PublicView.tsx
+++ b/app/src/components/PublicView.tsx
@@ -1,7 +1,7 @@
 import { PublicProfileSection } from "./PublicProfileSection";
 import { PublicBlockRenderer } from "./PublicBlockRenderer";
 import type { LinkData } from "./LinkCard";
-import { withBasePath } from "@/lib/base-path";
+import { withTenantBasePath } from "@/lib/base-path";
 import { getSocialRowData, getVideoData, isSocialRowContent } from "@/lib/link-blocks";
 import { isLinkVisibleNow } from "@/lib/link-visibility";
 import type { ProfileAppearance } from "@/lib/profile-appearance";
@@ -39,8 +39,8 @@ export const PublicView = ({
   showOrbitPageBadge = true,
   embedded = false,
 }: PublicViewProps) => {
-  const privacyHref = privacyPolicyUrl?.trim() ? withBasePath(privacyPolicyUrl.trim()) : undefined;
-  const cookieHref = cookiePolicyUrl?.trim() ? withBasePath(cookiePolicyUrl.trim()) : undefined;
+  const privacyHref = privacyPolicyUrl?.trim() ? withTenantBasePath(privacyPolicyUrl.trim()) : undefined;
+  const cookieHref = cookiePolicyUrl?.trim() ? withTenantBasePath(cookiePolicyUrl.trim()) : undefined;
   const hasCustomAvatar = Boolean(
     profile.showAvatar !== false &&
     profile.avatar &&

--- a/app/src/lib/api-client.ts
+++ b/app/src/lib/api-client.ts
@@ -1,4 +1,4 @@
-import { apiPath, getActiveBasePath } from './base-path';
+import { apiPath, getActiveBasePath, getConsentScope } from './base-path';
 import { resolveSafeBrowserHttpUrl } from './browser-network-policy';
 import { getHostedSurfaceConfig, isIntegratedHostedSurface } from './hosted-surface';
 
@@ -1089,6 +1089,14 @@ async function uploadVideoWithDirectFallback(
 export interface ConsentConfigData {
   mode: 'disabled' | 'hardcoded' | 'builder';
   enabled: boolean;
+  /** Public tenant namespace. Keeps consent isolated between orbitpage.net/slug pages. */
+  scope?: string;
+  controller?: {
+    name: string;
+    email: string;
+    country?: string;
+    address?: string;
+  };
   legalPolicies?: {
     showFooterLinks: boolean;
     privacyPolicy: {
@@ -1153,7 +1161,9 @@ export interface ConsentConfigData {
 /** Public (unauthenticated) consent config API — called from the public page */
 export const consentConfigPublicApi = {
   get: async (): Promise<{ success: boolean; data?: ConsentConfigData }> => {
-    return apiRequest<{ success: boolean; data?: ConsentConfigData }>('/consent-config/public');
+    const scope = getConsentScope();
+    const query = scope ? `?slug=${encodeURIComponent(scope)}` : '';
+    return apiRequest<{ success: boolean; data?: ConsentConfigData }>(`/consent-config/public${query}`);
   },
 };
 

--- a/app/src/lib/base-path.test.ts
+++ b/app/src/lib/base-path.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getConsentScope, withTenantBasePath } from './base-path';
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('tenant public paths', () => {
+  it('keeps policies at orbitpage.net/slug when rendered from a subpage', () => {
+    vi.stubGlobal('window', {
+      __ORBITPAGE_BASE_PATH__: '/studio/services',
+      __ORBITPAGE_CONSENT_SCOPE__: 'studio',
+      location: { pathname: '/studio/services' },
+    });
+    expect(getConsentScope()).toBe('studio');
+    expect(withTenantBasePath('/privacy')).toBe('/studio/privacy');
+  });
+
+  it('uses root paths on a custom domain while retaining the consent scope', () => {
+    vi.stubGlobal('window', {
+      __ORBITPAGE_BASE_PATH__: '',
+      __ORBITPAGE_CONSENT_SCOPE__: 'studio',
+      location: { pathname: '/services' },
+    });
+    expect(getConsentScope()).toBe('studio');
+    expect(withTenantBasePath('/cookies')).toBe('/cookies');
+  });
+});

--- a/app/src/lib/base-path.ts
+++ b/app/src/lib/base-path.ts
@@ -4,6 +4,7 @@ declare global {
   interface Window {
     __ORBITPAGE_BASE_PATH__?: string;
     __ORBITPAGE_API_BASE__?: string;
+    __ORBITPAGE_CONSENT_SCOPE__?: string;
   }
 }
 
@@ -30,6 +31,13 @@ export const getActiveBasePath = (): string => {
   return pathname === basePath || pathname.startsWith(`${basePath}/`) ? basePath : '';
 };
 
+export const getConsentScope = (): string => {
+  if (typeof window === 'undefined') return '';
+  const configured = window.__ORBITPAGE_CONSENT_SCOPE__?.trim();
+  if (configured) return configured;
+  return getActiveBasePath().split('/').filter(Boolean)[0] || '';
+};
+
 export const withBasePath = (path = '/'): string => {
   if (/^(?:[a-z][a-z\d+\-.]*:|\/\/)/i.test(path)) return path;
 
@@ -39,6 +47,20 @@ export const withBasePath = (path = '/'): string => {
     return normalizedPath;
   }
   return `${basePath}${normalizedPath}` || '/';
+};
+
+/** Resolve legal and consent routes against the root page, not an optional subpage. */
+export const withTenantBasePath = (path = '/'): string => {
+  if (/^(?:[a-z][a-z\d+\-.]*:|\/\/)/i.test(path)) return path;
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  const activeBase = getActiveBasePath();
+  const scope = getConsentScope();
+  if (!activeBase || !scope) return normalizedPath;
+  const tenantBase = activeBase === `/${scope}` || activeBase.startsWith(`/${scope}/`)
+    ? `/${scope}`
+    : activeBase;
+  if (normalizedPath === tenantBase || normalizedPath.startsWith(`${tenantBase}/`)) return normalizedPath;
+  return `${tenantBase}${normalizedPath}`;
 };
 
 export const apiPath = (path = ''): string => {

--- a/app/src/lib/consent-manager.test.ts
+++ b/app/src/lib/consent-manager.test.ts
@@ -110,6 +110,21 @@ describe('consentManager Google Consent Mode v2', () => {
     });
   });
 
+  it('isolates consent records between pages that share orbitpage.net', async () => {
+    const { consentManager } = await import('./consent-manager');
+
+    consentManager.init({ ...hardcodedConfig, scope: 'first-page' } as any);
+    consentManager.acceptAll('banner');
+    expect(consentManager.isGranted('analytics')).toBe(true);
+
+    consentManager.init({ ...hardcodedConfig, scope: 'second-page' } as any);
+    expect(consentManager.getConsent()).toBeNull();
+    expect(consentManager.isGranted('analytics')).toBe(false);
+
+    consentManager.init({ ...hardcodedConfig, scope: 'first-page' } as any);
+    expect(consentManager.isGranted('analytics')).toBe(true);
+  });
+
   it('uses a persisted CookieYes decision immediately on returning visits', async () => {
     const win = window as any;
     win.getCkyConsent = () => ({ categories: { accepted: ['functional', 'analytics'] } });

--- a/app/src/lib/consent-manager.ts
+++ b/app/src/lib/consent-manager.ts
@@ -25,6 +25,8 @@
  *   — call from custom CMP snippets to signal consent to OrbitPage
  */
 
+import { apiPath, getConsentScope } from './base-path';
+
 // ── Types ────────────────────────────────────────────────────────────────────
 
 export type ConsentCategory = 'necessary' | 'preferences' | 'analytics' | 'marketing';
@@ -33,6 +35,10 @@ export type ConsentCategory = 'necessary' | 'preferences' | 'analytics' | 'marke
 export interface ConsentRecord {
   /** Schema version — bump when the shape changes to invalidate old records */
   version: number;
+  /** Opaque receipt identifier also recorded by the managed backend. */
+  receiptId: string;
+  /** Tenant namespace used to isolate pages sharing orbitpage.net. */
+  scope: string;
   /** Policy version string from hardcoded config at time of consent */
   policyVersion: string;
   /** ISO timestamp of when consent was given */
@@ -94,17 +100,18 @@ export interface BuilderConfig {
 export interface ConsentConfig {
   mode: 'disabled' | 'hardcoded' | 'builder';
   enabled: boolean;
+  scope?: string;
   hardcoded?: HardcodedBannerConfig;
   builder?: BuilderConfig;
 }
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
-/** localStorage key for the user's consent record */
-const STORAGE_KEY = 'orbitpage_consent_v1';
+/** Prefix for tenant-scoped consent records. */
+const STORAGE_PREFIX = 'orbitpage_consent_v2:';
 
 /** Current schema version — increment to invalidate stored records on breaking changes */
-const SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
 
 /** Categories that are always active and cannot be opted out of */
 const ALWAYS_ACTIVE: ConsentCategory[] = ['necessary'];
@@ -128,6 +135,7 @@ class ConsentManager {
   private config: ConsentConfig | null = null;
   private consent: ConsentRecord | null = null;
   private initialized = false;
+  private scope = '';
   private listeners: Set<ConsentChangeListener> = new Set();
   private externalConsent: Partial<Record<ConsentCategory, boolean>> | null = null;
   private externalConsentExplicit = false;
@@ -149,6 +157,7 @@ class ConsentManager {
    */
   init(config: ConsentConfig): void {
     this.config = config;
+    this.scope = this._normalizeScope(config.scope || getConsentScope());
     this.consent = this._loadFromStorage();
     this.externalConsent = null;
     this.externalConsentExplicit = false;
@@ -425,6 +434,8 @@ class ConsentManager {
     const policyVersion = this.config?.hardcoded?.policyVersion ?? '1.0';
     const record: ConsentRecord = {
       version:       SCHEMA_VERSION,
+      receiptId:     this._receiptId(),
+      scope:         this.scope,
       policyVersion,
       timestamp:     new Date().toISOString(),
       source:        opts.source,
@@ -432,24 +443,62 @@ class ConsentManager {
     };
     this.consent = record;
     try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(record));
+      localStorage.setItem(this._storageKey(), JSON.stringify(record));
     } catch (e) {
       console.warn('[OrbitPageConsent] Could not persist consent to localStorage:', e);
     }
     this._notifyListeners();
+    this._recordReceipt(record);
   }
 
   private _loadFromStorage(): ConsentRecord | null {
     try {
-      const raw = localStorage.getItem(STORAGE_KEY);
+      const raw = localStorage.getItem(this._storageKey());
       if (!raw) return null;
       const parsed: ConsentRecord = JSON.parse(raw);
       // Reject records written by an incompatible schema version
-      if (parsed?.version !== SCHEMA_VERSION) return null;
+      if (parsed?.version !== SCHEMA_VERSION || parsed.scope !== this.scope || !parsed.receiptId) return null;
       return parsed;
     } catch {
       return null;
     }
+  }
+
+  private _normalizeScope(value: string): string {
+    return value.trim().toLowerCase().replace(/[^a-z0-9_-]/g, '').slice(0, 80) || 'default';
+  }
+
+  private _storageKey(): string {
+    return `${STORAGE_PREFIX}${this.scope}`;
+  }
+
+  private _receiptId(): string {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') return crypto.randomUUID();
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (char) => {
+      const random = Math.floor(Math.random() * 16);
+      return (char === 'x' ? random : (random & 0x3) | 0x8).toString(16);
+    });
+  }
+
+  private _recordReceipt(record: ConsentRecord): void {
+    if (!this.scope || typeof window === 'undefined' || !(window as any).__ORBITPAGE_STATIC_SNAPSHOT__) return;
+    fetch(apiPath('/consent/receipt'), {
+      method: 'POST',
+      mode: 'no-cors',
+      credentials: 'omit',
+      keepalive: true,
+      headers: { 'content-type': 'text/plain;charset=UTF-8' },
+      body: JSON.stringify({
+        receiptId: record.receiptId,
+        slug: this.scope,
+        policyVersion: record.policyVersion,
+        timestamp: record.timestamp,
+        source: record.source,
+        categories: record.categories,
+      }),
+    }).catch(() => {
+      // Consent remains valid locally even when the optional evidence endpoint is unavailable.
+    });
   }
 
   private _isConsentFresh(): boolean {

--- a/app/src/lib/public-runtime.ts
+++ b/app/src/lib/public-runtime.ts
@@ -1,4 +1,5 @@
 import { apiPath, withBasePath } from './base-path';
+import { consentManager } from './consent-manager';
 
 export const hasStaticPublicSnapshot = () =>
   typeof window !== 'undefined' && Boolean(
@@ -8,6 +9,7 @@ export const hasStaticPublicSnapshot = () =>
 export const trackPublicLinkClick = (id: string) => {
   if (!id) return;
   if (hasStaticPublicSnapshot()) {
+    if (!consentManager.isGranted('analytics')) return;
     sendManagedAnalyticsEvent('click', id);
     return;
   }
@@ -58,6 +60,7 @@ function sendManagedAnalyticsEvent(event: ManagedAnalyticsEvent, linkId?: string
 
 export function trackPublicPageView() {
   if (typeof window === 'undefined' || !hasStaticPublicSnapshot()) return;
+  if (!consentManager.isGranted('analytics')) return;
   const sessionKey = `${VIEW_SESSION_PREFIX}${window.location.pathname}${window.location.search}`;
   try {
     if (window.sessionStorage.getItem(sessionKey)) return;

--- a/app/src/pages/Index.tsx
+++ b/app/src/pages/Index.tsx
@@ -9,12 +9,13 @@ import { consentManager } from "@/lib/consent-manager";
 import { normalizeLinkDtos } from "@/lib/link-normalization";
 import { getEffectivePrivacyPolicyUrl } from "@/config/legal";
 import profileAvatar from "@/assets/profile-avatar.jpg";
-import { internalAssetPath, withBasePath } from "@/lib/base-path";
+import { internalAssetPath, withBasePath, withTenantBasePath } from "@/lib/base-path";
 import type { ProfileAppearance } from "@/lib/profile-appearance";
 import { isBundledProfileAvatar } from "@/lib/profile-avatar";
 import { trackPublicPageView } from "@/lib/public-runtime";
 import { UnderConstruction } from "@/components/UnderConstruction";
 import { collectCriticalPublicImageUrls, waitForCriticalPublicImages } from "@/lib/public-asset-readiness";
+import { getEmbedData } from "@/lib/link-blocks";
 
 interface ProfileData {
   name: string;
@@ -109,14 +110,41 @@ const Index = () => {
             ]);
         if (cancelled) return;
 
-        // Initialise consent manager with backend config.
-        // Must happen early so registerConsentDependentScript() below works correctly.
-        const cfg = consentRes?.data ?? { mode: 'disabled' as const, enabled: false };
-        consentManager.init(cfg as ConsentConfigData);
-        setConsentConfig(cfg as ConsentConfigData);
-
         const loadedTheme = normalizeTheme(pageData.theme);
         const normalizedLinks = normalizeLinkDtos(pageData.links);
+        const baseConfig = consentRes?.data ?? { mode: 'disabled' as const, enabled: false };
+        const requiredCategories = new Set<'preferences' | 'analytics' | 'marketing'>(['analytics']);
+        normalizedLinks.forEach((link) => {
+          if (link.type === 'map') requiredCategories.add('preferences');
+          if (link.type === 'embed') requiredCategories.add(getEmbedData(link.content).consentCategory || 'marketing');
+        });
+        const cfg: ConsentConfigData = baseConfig.mode === 'hardcoded' && baseConfig.hardcoded
+          ? {
+              ...baseConfig,
+              hardcoded: {
+                ...baseConfig.hardcoded,
+                categories: {
+                  preferences: {
+                    ...baseConfig.hardcoded.categories.preferences,
+                    enabled: baseConfig.hardcoded.categories.preferences.enabled || requiredCategories.has('preferences'),
+                  },
+                  analytics: {
+                    ...baseConfig.hardcoded.categories.analytics,
+                    enabled: baseConfig.hardcoded.categories.analytics.enabled || requiredCategories.has('analytics'),
+                  },
+                  marketing: {
+                    ...baseConfig.hardcoded.categories.marketing,
+                    enabled: baseConfig.hardcoded.categories.marketing.enabled || requiredCategories.has('marketing'),
+                  },
+                },
+              },
+            }
+          : baseConfig;
+
+        // Initialise consent before any optional network request or tracker can run.
+        consentManager.init(cfg);
+        setConsentConfig(cfg);
+
         applyTheme(loadedTheme);
         setTheme(loadedTheme);
         setBackgroundMedia(loadedTheme.backgroundMedia ?? null);
@@ -243,7 +271,9 @@ const Index = () => {
         }
 
         setLinks(normalizedLinks);
-        if (pageData.setupRequired !== true) trackPublicPageView();
+        if (pageData.setupRequired !== true) {
+          consentManager.registerConsentDependentScript('analytics', trackPublicPageView);
+        }
         setShowOrbitPageBadge(pageData.branding?.showOrbitPageBadge !== false);
         if (pageData.setupRequired === true) document.title = "Page under construction | OrbitPage";
         await waitForCriticalPublicImages(collectCriticalPublicImageUrls({
@@ -281,8 +311,8 @@ const Index = () => {
         hardcoded: {
           ...consentConfig.hardcoded,
           urls: {
-            privacyPolicy: profile.privacyPolicyUrl ? withBasePath(profile.privacyPolicyUrl) : '',
-            cookiePolicy: profile.cookiePolicyUrl ? withBasePath(profile.cookiePolicyUrl) : '',
+            privacyPolicy: profile.privacyPolicyUrl ? withTenantBasePath(profile.privacyPolicyUrl) : '',
+            cookiePolicy: profile.cookiePolicyUrl ? withTenantBasePath(profile.cookiePolicyUrl) : '',
           },
         },
       }

--- a/app/src/pages/LegalPolicyPage.tsx
+++ b/app/src/pages/LegalPolicyPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { consentConfigPublicApi, type ConsentConfigData } from "@/lib/api-client";
-import { withBasePath } from "@/lib/base-path";
+import { withBasePath, withTenantBasePath } from "@/lib/base-path";
 
 type PolicyKind = "privacy" | "cookie";
 type PolicyState = NonNullable<ConsentConfigData["legalPolicies"]>["privacyPolicy"];
@@ -66,7 +66,10 @@ export function LegalPolicyPage({ kind }: { kind: PolicyKind }) {
 
     const load = async () => {
       try {
-        const res = await consentConfigPublicApi.get();
+        const staticConfig = window.__ORBITPAGE_STATIC_SNAPSHOT__?.consentConfig;
+        const res = staticConfig
+          ? { success: true, data: staticConfig }
+          : await consentConfigPublicApi.get();
         if (cancelled) return;
         const nextPolicy = getPolicy(res.data, kind);
         setPolicy(nextPolicy);
@@ -110,7 +113,7 @@ export function LegalPolicyPage({ kind }: { kind: PolicyKind }) {
   return (
     <main className="min-h-screen bg-white px-4 py-10 text-slate-950" style={{ colorScheme: "light" }}>
       <div className="mx-auto w-full max-w-3xl">
-        <a className="text-sm text-slate-600 underline hover:text-blue-700" href={withBasePath('/')}>
+        <a className="text-sm text-slate-600 underline hover:text-blue-700" href={withTenantBasePath('/')}>
           Back to home
         </a>
 


### PR DESCRIPTION
## Summary
- isolate consent per public page on shared path hosting
- gate managed analytics, maps and embeds before category consent
- add editable Privacy/Cookie Policy starters and root-safe legal routes
- record consent decisions through the managed receipt endpoint

## Verification
- app: 41 files / 193 tests
- server: 14 files / 121 tests
- hosted runtime production build