### PR TITLE
fix: allow saving CMP without controller details

### DIFF
--- a/app/src/components/PrivacySettings.tsx
+++ b/app/src/components/PrivacySettings.tsx
@@ -44,6 +44,7 @@ import {
 import { useAppI18n } from '@/lib/i18n';
 import { consentConfigApi, type ConsentConfigData } from '@/lib/api-client';
 import { withBasePath } from '@/lib/base-path';
+import { normalizePrivacyController } from '@/lib/privacy-controller';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -1018,7 +1019,8 @@ export function PrivacySettings({
   const [cookieHostedFileName, setCookieHostedFileName] = useState('');
   const [privacyProviderConfig, setPrivacyProviderConfig] = useState('');
   const [cookieProviderConfig, setCookieProviderConfig] = useState('');
-  const [controller, setController] = useState({ name: pageName || '', email: '', country: '', address: '' });
+  // The page name remains a placeholder only: controller details are optional.
+  const [controller, setController] = useState({ name: '', email: '', country: '', address: '' });
 
   const [mode, setMode] = useState<ConsentMode>('disabled');
   const [enabled, setEnabled] = useState(false);
@@ -1181,8 +1183,12 @@ export function PrivacySettings({
     try {
       const nextPrivacyPolicyUrl = resolvedPrivacyPolicyUrl;
       const nextCookiePolicyUrl = resolvedCookiePolicyUrl;
-      if ((controller.name.trim() || controller.email.trim()) && (!controller.name.trim() || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(controller.email.trim()))) {
-        setSaveError('Add a valid controller name and privacy email, or leave both fields empty.');
+      const normalizedController = normalizePrivacyController(controller);
+      if (normalizedController.error) {
+        setSaveError(tr(
+          'Add both the controller name and a valid privacy email, or leave both fields empty.',
+          'Inserisci sia il nome del titolare sia un’email privacy valida, oppure lascia entrambi i campi vuoti.',
+        ));
         return;
       }
 
@@ -1245,10 +1251,14 @@ export function PrivacySettings({
         },
       };
 
-      const normalizedController = controller.name.trim() && controller.email.trim()
-        ? { name: controller.name.trim(), email: controller.email.trim(), country: controller.country.trim(), address: controller.address.trim() }
-        : undefined;
-      const res = await consentConfigApi.update({ mode, enabled, controller: normalizedController, legalPolicies, hardcoded, builder: nextBuilder });
+      const res = await consentConfigApi.update({
+        mode,
+        enabled,
+        controller: normalizedController.controller,
+        legalPolicies,
+        hardcoded,
+        builder: nextBuilder,
+      });
       if (!res.success) {
         setSaveError((res as { error?: string }).error || 'Save failed.');
       } else {
@@ -1464,14 +1474,15 @@ export function PrivacySettings({
                   type="button"
                   variant="outline"
                   onClick={() => {
-                    if (!controller.name.trim() || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(controller.email.trim())) {
+                    const normalizedController = normalizePrivacyController(controller);
+                    if (!normalizedController.controller) {
                       setSaveError(tr('Add the controller name and a valid privacy email first.', 'Inserisci prima il nome del titolare e un’email privacy valida.'));
                       return;
                     }
                     const policyVersion = new Date().toISOString().slice(0, 10);
                     const docs = generatedPolicies({
                       language: document.documentElement.lang.toLowerCase().startsWith('it') ? 'it' : 'en',
-                      controller: { ...controller, name: controller.name.trim(), email: controller.email.trim() },
+                      controller: normalizedController.controller,
                       policyVersion,
                       categories: hardcoded.categories,
                     });

--- a/app/src/lib/privacy-controller.test.ts
+++ b/app/src/lib/privacy-controller.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { normalizePrivacyController } from './privacy-controller';
+
+describe('normalizePrivacyController', () => {
+  it('allows the optional controller fields to remain empty', () => {
+    expect(normalizePrivacyController({
+      name: '  ',
+      email: '',
+      country: 'Italy',
+      address: '',
+    })).toEqual({ controller: undefined, error: null });
+  });
+
+  it('requires name and email as a pair', () => {
+    expect(normalizePrivacyController({
+      name: 'Studio Rossi',
+      email: '',
+    })).toEqual({ controller: undefined, error: 'incomplete' });
+    expect(normalizePrivacyController({
+      name: '',
+      email: 'privacy@example.com',
+    })).toEqual({ controller: undefined, error: 'incomplete' });
+  });
+
+  it('normalizes a complete controller', () => {
+    expect(normalizePrivacyController({
+      name: '  Studio Rossi ',
+      email: ' privacy@example.com ',
+      country: ' Italy ',
+      address: ' Via Roma 1 ',
+    })).toEqual({
+      controller: {
+        name: 'Studio Rossi',
+        email: 'privacy@example.com',
+        country: 'Italy',
+        address: 'Via Roma 1',
+      },
+      error: null,
+    });
+  });
+
+  it('rejects malformed email addresses', () => {
+    expect(normalizePrivacyController({
+      name: 'Studio Rossi',
+      email: 'privacy@localhost',
+    })).toEqual({ controller: undefined, error: 'invalid-email' });
+  });
+});

--- a/app/src/lib/privacy-controller.ts
+++ b/app/src/lib/privacy-controller.ts
@@ -1,0 +1,45 @@
+export interface PrivacyControllerInput {
+  name: string;
+  email: string;
+  country?: string;
+  address?: string;
+}
+
+export interface NormalizedPrivacyController {
+  name: string;
+  email: string;
+  country: string;
+  address: string;
+}
+
+export type PrivacyControllerResult =
+  | { controller: undefined; error: null }
+  | { controller: NormalizedPrivacyController; error: null }
+  | { controller: undefined; error: 'incomplete' | 'invalid-email' };
+
+const PRIVACY_EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function normalizePrivacyController(input: PrivacyControllerInput): PrivacyControllerResult {
+  const name = input.name.trim();
+  const email = input.email.trim();
+
+  if (!name && !email) {
+    return { controller: undefined, error: null };
+  }
+  if (!name || !email) {
+    return { controller: undefined, error: 'incomplete' };
+  }
+  if (!PRIVACY_EMAIL_PATTERN.test(email)) {
+    return { controller: undefined, error: 'invalid-email' };
+  }
+
+  return {
+    controller: {
+      name,
+      email,
+      country: input.country?.trim() || '',
+      address: input.address?.trim() || '',
+    },
+    error: null,
+  };
+}


### PR DESCRIPTION
## What changed

- Keep optional controller fields empty instead of pre-filling the page name.
- Centralize controller normalization and validation.
- Localize the save validation message.
- Add unit coverage for empty, incomplete, valid, and malformed controller details.

## Root cause

The form used the page name as the actual initial controller name while leaving the privacy email empty. An untouched form therefore looked partially completed to validation and could never take the documented “leave both fields empty” path.

## Impact

Users can now save CMP settings without controller details. When they choose to provide controller details or generate starter policies, name and a valid email remain required together.

## Validation

- `npm test -- --run` — 42 files, 197 tests passed
- `npm run build:hosted` — passed
- ESLint on changed files — no errors