### PR TITLE
fix: accept iubenda installation snippets

### DIFF
--- a/app/src/components/PrivacySettings.tsx
+++ b/app/src/components/PrivacySettings.tsx
@@ -115,7 +115,9 @@ const DEFAULT_BUILDER: NonNullable<ConsentConfigData['builder']> = {
 
 function isBuilderProviderConfigured(builder: NonNullable<ConsentConfigData['builder']>) {
   const cfg = builder.providerConfig;
-  if (builder.provider === 'iubenda') return !!cfg.siteId?.trim() && !!cfg.cookiePolicyId?.trim();
+  if (builder.provider === 'iubenda') {
+    return !!cfg.headSnippet?.trim() || (!!cfg.siteId?.trim() && !!cfg.cookiePolicyId?.trim());
+  }
   if (builder.provider === 'cookiebot' || builder.provider === 'cookieyes') return !!cfg.scriptId?.trim();
   if (builder.provider === 'onetrust') return !!cfg.siteId?.trim();
   return !!cfg.headSnippet?.trim();
@@ -851,6 +853,7 @@ function BuilderForm({
   cfg: NonNullable<ConsentConfigData['builder']>;
   onChange: (updates: Partial<NonNullable<ConsentConfigData['builder']>>) => void;
 }) {
+  const { tr } = useAppI18n();
   const updateCfg = (updates: Partial<typeof cfg.providerConfig>) =>
     onChange({ providerConfig: { ...cfg.providerConfig, ...updates } });
 
@@ -879,14 +882,22 @@ function BuilderForm({
       </FieldRow>
 
       {cfg.provider === 'iubenda' && (
-        <div className="grid gap-4 sm:grid-cols-2">
-          <FieldRow label="Site ID" description="The site ID from your iubenda project.">
-            <Input className="admin-input font-mono text-xs" value={cfg.providerConfig.siteId ?? ''} onChange={(e) => updateCfg({ siteId: e.target.value })} />
-          </FieldRow>
-          <FieldRow label="Cookie Policy ID" description="The Cookie Policy ID linked to the CMP.">
-            <Input className="admin-input font-mono text-xs" value={cfg.providerConfig.cookiePolicyId ?? ''} onChange={(e) => updateCfg({ cookiePolicyId: e.target.value })} />
-          </FieldRow>
-        </div>
+        <FieldRow
+          label={tr('iubenda installation script', 'Script di installazione iubenda')}
+          description={tr(
+            'In iubenda, open Manage and Embed and paste the complete Privacy Controls and Cookie Solution snippet.',
+            'In iubenda apri Gestisci e incorpora e incolla lo snippet completo di Privacy Controls and Cookie Solution.',
+          )}
+        >
+          <Textarea
+            className="admin-input min-h-[180px] resize-y font-mono text-xs"
+            value={cfg.providerConfig.headSnippet ?? ''}
+            onChange={(event) => updateCfg({ headSnippet: event.target.value, bodySnippet: '' })}
+            placeholder={'<script src="https://embeds.iubenda.com/widgets/…"></script>'}
+            maxLength={10000}
+            spellCheck={false}
+          />
+        </FieldRow>
       )}
 
       {(cfg.provider === 'cookiebot' || cfg.provider === 'cookieyes') && (

--- a/app/src/lib/consent-manager.test.ts
+++ b/app/src/lib/consent-manager.test.ts
@@ -153,6 +153,20 @@ describe('consentManager Google Consent Mode v2', () => {
     expect(consentManager.isGranted('analytics')).toBe(false);
   });
 
+  it('injects the complete iubenda installation snippet without requiring separate IDs', async () => {
+    vi.useFakeTimers();
+    const snippet = '<script src="https://embeds.iubenda.com/widgets/site-code.js"></script>';
+    const { consentManager } = await import('./consent-manager');
+    const injectSnippet = vi
+      .spyOn(consentManager as any, '_injectHtmlSnippet')
+      .mockReturnValue(true);
+
+    consentManager.init(builderConfig('iubenda', { headSnippet: snippet }) as any);
+    (consentManager as any)._injectIubenda({ headSnippet: snippet });
+
+    expect(injectSnippet).toHaveBeenCalledWith(document.head, snippet, 'orbitpage-cmp-script');
+  });
+
   it('preserves granular GCM v2 advertising signals from an external CMP update', async () => {
     const win = window as any;
     win.dataLayer.push(['consent', 'update', {

--- a/app/src/lib/consent-manager.ts
+++ b/app/src/lib/consent-manager.ts
@@ -651,8 +651,14 @@ class ConsentManager {
   // ── Builder Provider Injectors ─────────────────────────────────────────────
 
   private _injectIubenda(cfg: BuilderConfig['providerConfig']): void {
+    if (cfg.headSnippet?.trim()) {
+      this._wireIubendaConsentEvents();
+      this._injectHtmlSnippet(document.head, cfg.headSnippet, 'orbitpage-cmp-script');
+      return;
+    }
+
     if (!cfg.siteId || !cfg.cookiePolicyId) {
-      console.warn('[OrbitPageConsent] Iubenda: missing siteId or cookiePolicyId');
+      console.warn('[OrbitPageConsent] Iubenda: missing installation snippet');
       return;
     }
     this._wireIubendaConsentEvents();


### PR DESCRIPTION
## What changed

- Replace the manual iubenda Site ID and Cookie Policy ID fields with one installation-snippet textarea.
- Inject the complete trusted snippet supplied by iubenda and retain OrbitPage consent event wiring.
- Keep legacy ID-based configurations working for backwards compatibility.
- Add coverage proving a pasted iubenda snippet works without separate IDs.

## Root cause

The UI exposed internal parameters that iubenda already embeds in its generated integration code. This forced users to extract values that iubenda explicitly says they normally do not need to know.

## Impact

Users can copy the complete Privacy Controls and Cookie Solution snippet from iubenda’s Manage and Embed screen and paste it directly into OrbitPage.

## Validation

- `npm test -- --run` — 42 files, 198 tests passed
- `npm run build:hosted` — passed
- ESLint on changed files — no errors