### PR TITLE
Fix public page boot failures

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -3,7 +3,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Navigate, Routes, Route, useLocation } from "react-router-dom";
-import { lazy, Suspense } from "react";
+import { Component, lazy, Suspense, type ErrorInfo, type ReactNode } from "react";
 import { getActiveBasePath } from "@/lib/base-path";
 import { AppI18nProvider } from "@/lib/i18n";
 
@@ -17,6 +17,66 @@ const NotFound = lazy(() => import("./pages/NotFound"));
 const routerBaseName = getActiveBasePath();
 
 const queryClient = new QueryClient();
+
+class ApplicationErrorBoundary extends Component<
+  { children: ReactNode },
+  { failed: boolean }
+> {
+  state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("OrbitPage rendering failed.", error, info);
+    window.__ORBITPAGE_BOOT_REPORT__?.("react-error");
+    window.__ORBITPAGE_BOOT_FAIL__?.("react-error", false);
+  }
+
+  render() {
+    if (!this.state.failed) return this.props.children;
+
+    return (
+      <main
+        role="alert"
+        style={{
+          minHeight: "100dvh",
+          display: "grid",
+          placeItems: "center",
+          padding: "24px",
+          background: "#f8fafc",
+          color: "#0f172a",
+          fontFamily: "system-ui, sans-serif",
+        }}
+      >
+        <div style={{ maxWidth: "420px", textAlign: "center" }}>
+          <h1 style={{ margin: 0, fontSize: "1.25rem" }}>Impossibile caricare la pagina</h1>
+          <p style={{ margin: "10px 0 20px", color: "#64748b" }}>
+            Controlla la connessione e riprova.
+          </p>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            style={{
+              minHeight: "42px",
+              border: 0,
+              borderRadius: "10px",
+              padding: "10px 18px",
+              background: "#2563eb",
+              color: "#fff",
+              font: "inherit",
+              fontWeight: 700,
+              cursor: "pointer",
+            }}
+          >
+            Riprova
+          </button>
+        </div>
+      </main>
+    );
+  }
+}
 
 function RoutedApplication() {
   const location = useLocation();
@@ -44,15 +104,17 @@ function RoutedApplication() {
 }
 
 const App = () => (
-  <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter basename={routerBaseName || undefined}>
-        <RoutedApplication />
-      </BrowserRouter>
-    </TooltipProvider>
-  </QueryClientProvider>
+  <ApplicationErrorBoundary>
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <Toaster />
+        <Sonner />
+        <BrowserRouter basename={routerBaseName || undefined}>
+          <RoutedApplication />
+        </BrowserRouter>
+      </TooltipProvider>
+    </QueryClientProvider>
+  </ApplicationErrorBoundary>
 );
 
 export default App;

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -7,7 +7,11 @@ const activeBasePath = getActiveBasePath();
 const activeHomePath = activeBasePath || '/';
 
 if (window.location.pathname !== activeHomePath) {
-  document.body.classList.remove('orbitpage-booting');
+  if (window.__ORBITPAGE_BOOT_READY__) {
+    window.__ORBITPAGE_BOOT_READY__();
+  } else {
+    document.body.classList.remove('orbitpage-booting');
+  }
 }
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/app/src/pages/Index.tsx
+++ b/app/src/pages/Index.tsx
@@ -87,10 +87,16 @@ const Index = () => {
   useLayoutEffect(() => {
     if (loading) return;
     const frame = window.requestAnimationFrame(() => {
-      document.body.classList.remove('orbitpage-booting');
+      if (loadFailed) {
+        window.__ORBITPAGE_BOOT_FAIL__?.('data-load', false);
+      } else if (window.__ORBITPAGE_BOOT_READY__) {
+        window.__ORBITPAGE_BOOT_READY__();
+      } else {
+        document.body.classList.remove('orbitpage-booting');
+      }
     });
     return () => window.cancelAnimationFrame(frame);
-  }, [loading]);
+  }, [loadFailed, loading]);
 
   // Load all public page data in one request so the default UI never flashes.
   useEffect(() => {
@@ -287,6 +293,7 @@ const Index = () => {
       } catch (error) {
         console.error('Error loading data:', error);
         if (!cancelled) {
+          window.__ORBITPAGE_BOOT_REPORT__?.('data-load');
           setLoadFailed(true);
           setLoading(false);
         }
@@ -300,7 +307,47 @@ const Index = () => {
     };
   }, []);
 
-  if (loading || loadFailed) return null;
+  if (loading) return null;
+  if (loadFailed) {
+    return (
+      <main
+        role="alert"
+        style={{
+          minHeight: '100dvh',
+          display: 'grid',
+          placeItems: 'center',
+          padding: '24px',
+          background: '#f8fafc',
+          color: '#0f172a',
+          fontFamily: 'system-ui, sans-serif',
+        }}
+      >
+        <div style={{ maxWidth: '420px', textAlign: 'center' }}>
+          <h1 style={{ margin: 0, fontSize: '1.25rem' }}>Impossibile caricare la pagina</h1>
+          <p style={{ margin: '10px 0 20px', color: '#64748b' }}>
+            Controlla la connessione e riprova.
+          </p>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            style={{
+              minHeight: '42px',
+              border: 0,
+              borderRadius: '10px',
+              padding: '10px 18px',
+              background: '#2563eb',
+              color: '#fff',
+              font: 'inherit',
+              fontWeight: 700,
+              cursor: 'pointer',
+            }}
+          >
+            Riprova
+          </button>
+        </div>
+      </main>
+    );
+  }
   if (setupRequired) return <UnderConstruction />;
 
   // Merge profile-level policy URLs into the consent config so the banner and footer

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -12,3 +12,9 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+interface Window {
+  __ORBITPAGE_BOOT_READY__?: () => void;
+  __ORBITPAGE_BOOT_FAIL__?: (reason?: string, autoRetry?: boolean) => void;
+  __ORBITPAGE_BOOT_REPORT__?: (reason?: string) => void;
+}


### PR DESCRIPTION
## Cosa cambia

- aggiunge un fallback visibile quando il caricamento dati della pagina pubblica fallisce
- intercetta gli errori di rendering React e dei chunk lazy
- segnala al watchdog edge quando l'app è pronta o non può avviarsi

## Perché

La pagina pubblica nasconde intenzionalmente il root durante il bootstrap. Se il runtime o il caricamento dati fallivano, React restituiva `null` e il body restava nascosto, producendo una pagina completamente bianca.

## Impatto

Il visitatore vede ora un messaggio chiaro con pulsante di retry invece di una pagina bianca; gli errori React e data-load vengono inoltre notificati al recovery handler edge.

## Verifica

- `npm test -- --run` — 198 test superati
- `npm run build:hosted` — build di produzione riuscita
- `git diff --check` — nessun errore